### PR TITLE
Add news agent example using Google ADK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# News Agent Example
+
+This repo provides a minimal example of creating an agent using the [Google Agent Development Kit](https://google.github.io/adk-docs/).
+The agent can search the web and load pages to answer questions about current news.
+
+## Requirements
+- Python 3.12+
+- `google-adk` Python package
+- A Google API key or Vertex AI project configured for Gemini models
+
+## Setup
+1. Create and activate a virtual environment (optional):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install `google-adk`:
+   ```bash
+   pip install google-adk
+   ```
+3. Create a folder named `news_agent/` with the provided `agent.py` and `__init__.py` files.
+4. Add a `.env` file to configure your API credentials. For example using Google AI Studio:
+   ```dotenv
+   GOOGLE_GENAI_USE_VERTEXAI=FALSE
+   GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_API_KEY_HERE
+   ```
+   Or for Vertex AI:
+   ```dotenv
+   GOOGLE_GENAI_USE_VERTEXAI=TRUE
+   GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID
+   GOOGLE_CLOUD_LOCATION=LOCATION
+   ```
+
+## Running the agent
+From the repository root, run:
+```bash
+adk run news_agent
+```
+This starts an interactive CLI where you can ask questions about recent news.

--- a/news_agent/__init__.py
+++ b/news_agent/__init__.py
@@ -1,0 +1,1 @@
+from .agent import root_agent

--- a/news_agent/agent.py
+++ b/news_agent/agent.py
@@ -1,0 +1,14 @@
+from google.adk.agents import Agent
+from google.adk.tools import google_search
+from google.adk.tools.load_web_page import load_web_page
+
+root_agent = Agent(
+    name="news_agent",
+    model="gemini-2.0-pro",
+    description="Agent that can search the web and answer questions about current news.",
+    instruction=(
+        "Use google_search to look up recent news articles. "
+        "Use load_web_page to fetch page contents if needed."
+    ),
+    tools=[google_search, load_web_page],
+)


### PR DESCRIPTION
## Summary
- add sample agent using google-adk to query current news
- document setup and usage

## Testing
- `adk --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6849bab92d58832eb450c7274d9b5fb6